### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
 git+https://github.com/autonomousvision/kitti360Scripts.git
 open3d==0.15.2
-supervisely==6.72.85
+supervisely==6.73.564
 transforms3d==0.4.1

--- a/supervisely_app/config.json
+++ b/supervisely_app/config.json
@@ -1,6 +1,7 @@
 {
   "name": "Import KITTI-360",
   "type": "app",
+  "instance_version": "6.15.60",
   "categories": [
     "import",
     "pointclouds"

--- a/supervisely_app/config.json
+++ b/supervisely_app/config.json
@@ -6,7 +6,7 @@
     "pointclouds"
   ],
   "description": "Import Pointcloud Episodes from KITTI-360 format",
-  "docker_image": "supervisely/import-export:0.0.5",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "supervisely_app/main.py",
   "task_location": "workspace_tasks",
   "isolate": true,


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
