### PR TITLE
fix: rename pointcloud -> point cloud

### DIFF
--- a/supervisely_app/README.md
+++ b/supervisely_app/README.md
@@ -22,12 +22,12 @@
 
 # Overview
 
-Application imports **Supervisely Pointcloud Episodes** from KITTI-360 format.
+Application imports **Supervisely Point Cloud Episodes** from KITTI-360 format.
 
 <img src="https://github.com/supervisely-ecosystem/import-kitti-360/releases/download/v0.0.4/pointcloud-episodes.gif?raw=true" style="width: 100%;"/>
 
 Application key points:  
-- `3D Raw Velodyne Pointclouds` supported
+- `3D Raw Velodyne Point Clouds` supported
 - `3D BBoxes` supported
 - `2D Rectified Images from Perspective Camera (00)` supported
 

--- a/supervisely_app/config.json
+++ b/supervisely_app/config.json
@@ -6,7 +6,7 @@
     "import",
     "pointclouds"
   ],
-  "description": "Import Pointcloud Episodes from KITTI-360 format",
+  "description": "Import Point Cloud Episodes from KITTI-360 format",
   "docker_image": "supervisely/import-export:6.73.577",
   "main_script": "supervisely_app/main.py",
   "task_location": "workspace_tasks",


### PR DESCRIPTION
Renames all occurrences of pointcloud/Pointcloud/Pointclouds to the correct two-word form in README.md and config.json (name, description, poster). URLs are preserved unchanged.